### PR TITLE
build: change Dockerfile to use debian:jessie

### DIFF
--- a/hack/deploy/Dockerfile
+++ b/hack/deploy/Dockerfile
@@ -1,7 +1,13 @@
-FROM alpine
+FROM debian:jessie
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get -yy -q install \
+    iptables \
+    ca-certificates \
+    && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* # CACHEBUST
 
 ADD _output/bin/kenc /usr/local/bin
-
-RUN apk --no-cache --update add iptables
 
 CMD ["/usr/local/bin/kenc"]


### PR DESCRIPTION
We need to use flock v2+ .
fix https://github.com/coreos/kenc/issues/38